### PR TITLE
images: editorial change

### DIFF
--- a/docs/images-Ⓣ.html
+++ b/docs/images-Ⓣ.html
@@ -30,7 +30,7 @@
             <p>The results are displayed visually on the page:</p>
             <ul>
                 <li>A green bubble (✔) indicates a specified and non-empty alternative text.</li>
-                <li>A red bubble (✖) indicates a missing alternative text.</li>
+                <li>A red bubble (✖) indicates a missing attribute.</li>
                 <li>An orange bubble (💀) indicates either an empty alternative text (decorative image) or the
                     dependence on the title attribute. Both case aren't necessarily an error but you should check
                     whether you really want this.


### PR DESCRIPTION
editorial change: "missing alt attribute" instead of "missing alternative text"